### PR TITLE
✨ Create a Helm chart for OTP

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,10 +8,12 @@ on:
 permissions:
   contents: write
   packages: write
- 
-# env:
-#   REGISTRY: ghcr.io
-#   CONTROLLER_IMAGE: kubestellar/ocm-transport-plugin/transport-controller
+
+env:
+  REGISTRY: ghcr.io
+  CONTROLLER_IMAGE: kubestellar/ocm-transport-plugin/transport-controller
+  IMAGE_NAME: ${{ github.repository }}/chart
+  CHART_PATH: ./chart
 
 jobs:
   goreleaser:
@@ -43,3 +45,21 @@ jobs:
         KO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         USER: ${{ github.actor }}
         EMAIL: ${{ github.actor}}@users.noreply.github.com
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Package and push chart
+      run: |
+        make chart IMG=${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{github.ref_name}}
+        helm package ${{ env.CHART_PATH }} --destination . --version ${{github.ref_name}} --app-version ${{github.ref_name}} --dependency-update
+        helm push ./*.tgz oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -60,6 +60,6 @@ jobs:
 
     - name: Package and push chart
       run: |
-        sed -i 's@otp_controller_image@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/template/controller.yaml
+        sed -i 's@otp_controller_image@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
         helm package ${{ env.CHART_PATH }} --destination . --version ${{github.ref_name}} --app-version ${{ github.ref_name }} --dependency-update
         helm push ./*.tgz oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -60,6 +60,6 @@ jobs:
 
     - name: Package and push chart
       run: |
-        make chart IMG=${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{github.ref_name}}
-        helm package ${{ env.CHART_PATH }} --destination . --version ${{github.ref_name}} --app-version ${{github.ref_name}} --dependency-update
+        sed -i 's@otp_controller_image@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/template/controller.yaml
+        helm package ${{ env.CHART_PATH }} --destination . --version ${{github.ref_name}} --app-version ${{ github.ref_name }} --dependency-update
         helm push ./*.tgz oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -60,6 +60,7 @@ jobs:
 
     - name: Package and push chart
       run: |
-        sed -i 's@otp_controller_image@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
-        helm package ${{ env.CHART_PATH }} --destination . --version ${{github.ref_name}} --app-version ${{ github.ref_name }} --dependency-update
+        chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
+        sed -i 's@OTP_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
+        helm package ${{ env.CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion} --dependency-update
         helm push ./*.tgz oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: ocm-transport-plugin
+description: Helm chart to install the OCM transport operator
+type: application
+version: 0.1.0 # automatically set by goreleaser helm package
+appVersion: 0.1.0 # automatically set by goreleaser helm package

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -16,45 +16,45 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: otp-controller-manager
+  name: transport-controller-sa
   namespace: {{.Values.wds_cp_name}}-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: otp-leader-election-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: Role
+# metadata:
+#   name: otp-leader-election-role
+# rules:
+# - apiGroups:
+#   - ""
+#   resources:
+#   - configmaps
+#   verbs:
+#   - get
+#   - list
+#   - watch
+#   - create
+#   - update
+#   - patch
+#   - delete
+# - apiGroups:
+#   - coordination.k8s.io
+#   resources:
+#   - leases
+#   verbs:
+#   - get
+#   - list
+#   - watch
+#   - create
+#   - update
+#   - patch
+#   - delete
+# - apiGroups:
+#   - ""
+#   resources:
+#   - events
+#   verbs:
+#   - create
+#   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -86,19 +86,19 @@ rules:
   - get
   - patch
   - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: otp-leader-election-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: otp-leader-election-role
-subjects:
-- kind: ServiceAccount
-  name: otp-controller-manager
-  namespace: '{{.Values.wds_cp_name}}-system'
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: otp-leader-election-rolebinding
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: Role
+#   name: otp-leader-election-role
+# subjects:
+# - kind: ServiceAccount
+#   name: transport-controller-sa
+#   namespace: '{{.Values.wds_cp_name}}-system'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -110,7 +110,7 @@ roleRef:
   name: '{{.Values.wds_cp_name}}-otp-manager-role'
 subjects:
   - kind: ServiceAccount
-    name: otp-controller-manager
+    name: transport-controller-sa
     namespace: '{{.Values.wds_cp_name}}-system'
 ---
 apiVersion: v1
@@ -159,7 +159,7 @@ spec:
       labels:
         name: transport-controller
     spec:
-      serviceAccountName: otp-controller-manager
+      serviceAccountName: transport-controller-sa
       initContainers:
       - name: setup-wds-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
@@ -181,8 +181,8 @@ spec:
           mountPath: /mnt/shared
       containers:
         - name: transport-controller
-          image: otp_controller_image
-          # image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:latest
+          # image: OTP_IMAGE_PLACEHOLDER
+          image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:latest
           imagePullPolicy: IfNotPresent
           args:
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -81,8 +81,8 @@ spec:
           mountPath: /mnt/shared
       containers:
         - name: transport-controller
-          image: {{ .Values.controller.image }}:{{ .Values.controller.tag | default "latest" }}
-          imagePullPolicy: {{ .Values.controller.pullPolicy | default "Always" }}
+          image: otp_controller_image
+          imagePullPolicy: IfNotPresent
           args:
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
           - --wds-kubeconfig=/mnt/shared/wds-kubeconfig
@@ -92,9 +92,9 @@ spec:
           - name: shared-volume
             mountPath: /mnt/shared
             readOnly: true
-      {{- if .Values.local_image }}
+      {{- if .Values.HOST_IP }}
       hostAliases:
-      - ip: ${HOST_IP}
+      - ip: {{ .Values.HOST_IP }}
         hostnames: [ "{{ .Values.wds_cp_name }}.localtest.me", "{{ .Values.transport_cp_name }}.localtest.me" ]
       {{- end }}
       volumes:

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -26,24 +26,23 @@ data:
     # The function returns the requested kubeconfig's content in base64.
     # it assumes the kubeconfig context is set to access the hosting cluster.
 
-    cpname="\$1"
-    get_incluster_key="\$2"
+    cpname="$1"
+    get_incluster_key="$2"
 
     key=""
-    if [[ "\$get_incluster_key" == "true" ]]; then
-      key=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.inClusterKey}');
+    if [[ "$get_incluster_key" == "true" ]]; then
+      key=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.inClusterKey}');
     else
-      key=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.key}');
+      key=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.key}');
     fi
 
     # get secret details
-    secret_name=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.name}')
-    secret_namespace=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.namespace}')
+    secret_name=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.namespace}')
 
     # get the kubeconfig in base64
-    kubectl get secret \$secret_name -n \$secret_namespace -o=jsonpath="{.data.\$key}"
+    kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,6 +81,7 @@ spec:
       containers:
         - name: transport-controller
           image: otp_controller_image
+          # image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:latest
           imagePullPolicy: IfNotPresent
           args:
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -18,49 +18,11 @@ kind: ServiceAccount
 metadata:
   name: transport-controller-sa
   namespace: {{.Values.wds_cp_name}}-system
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: Role
-# metadata:
-#   name: otp-leader-election-role
-# rules:
-# - apiGroups:
-#   - ""
-#   resources:
-#   - configmaps
-#   verbs:
-#   - get
-#   - list
-#   - watch
-#   - create
-#   - update
-#   - patch
-#   - delete
-# - apiGroups:
-#   - coordination.k8s.io
-#   resources:
-#   - leases
-#   verbs:
-#   - get
-#   - list
-#   - watch
-#   - create
-#   - update
-#   - patch
-#   - delete
-# - apiGroups:
-#   - ""
-#   resources:
-#   - events
-#   verbs:
-#   - create
-#   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: '{{.Values.wds_cp_name}}-otp-manager-role'
+  name: transport-controller-role
 rules:
 - apiGroups:
   - ""
@@ -86,28 +48,15 @@ rules:
   - get
   - patch
   - update
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: RoleBinding
-# metadata:
-#   name: otp-leader-election-rolebinding
-# roleRef:
-#   apiGroup: rbac.authorization.k8s.io
-#   kind: Role
-#   name: otp-leader-election-role
-# subjects:
-# - kind: ServiceAccount
-#   name: transport-controller-sa
-#   namespace: '{{.Values.wds_cp_name}}-system'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: '{{.Values.wds_cp_name}}-otp-manager-rolebinding'
+  name: transport-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{.Values.wds_cp_name}}-otp-manager-role'
+  name: transport-controller-role
 subjects:
   - kind: ServiceAccount
     name: transport-controller-sa
@@ -181,8 +130,8 @@ spec:
           mountPath: /mnt/shared
       containers:
         - name: transport-controller
-          # image: OTP_IMAGE_PLACEHOLDER
-          image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:latest
+          image: OTP_IMAGE_PLACEHOLDER
+          # image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:latest
           imagePullPolicy: IfNotPresent
           args:
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -1,0 +1,106 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: transport-controller-config
+  namespace: {{ .Values.wds_cp_name }}-system
+data:
+  get-kubeconfig.sh: |
+    #!/bin/bash
+    # this script receives a ControlPlane name and a parameter
+    # that determines whether to extract the ControlPlane's in-cluster kubeconfig
+    # or the external kubeconfig (if set to "true", the first will be retrieved).
+    # The function returns the requested kubeconfig's content in base64.
+    # it assumes the kubeconfig context is set to access the hosting cluster.
+
+    cpname="\$1"
+    get_incluster_key="\$2"
+
+    key=""
+    if [[ "\$get_incluster_key" == "true" ]]; then
+      key=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.inClusterKey}');
+    else
+      key=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.key}');
+    fi
+
+    # get secret details
+    secret_name=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=\$(kubectl get controlplane \$cpname -o=jsonpath='{.status.secretRef.namespace}')
+
+    # get the kubeconfig in base64
+    kubectl get secret \$secret_name -n \$secret_namespace -o=jsonpath="{.data.\$key}"
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transport-controller
+  namespace: {{ .Values.wds_cp_name }}-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: transport-controller
+  template:
+    metadata:
+      labels:
+        name: transport-controller
+    spec:
+      serviceAccountName: kubestellar-controller-manager
+      initContainers:
+      - name: setup-wds-kubeconfig
+        image: quay.io/kubestellar/kubectl:1.27.8
+        imagePullPolicy: Always
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{ .Values.wds_cp_name }} true | base64 -d > /mnt/shared/wds-kubeconfig"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /mnt/config
+        - name: shared-volume
+          mountPath: /mnt/shared
+      - name: setup-imbs-kubeconfig
+        image: quay.io/kubestellar/kubectl:1.27.8
+        imagePullPolicy: Always
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{ .Values.transport_cp_name }} true | base64 -d > /mnt/shared/transport-kubeconfig"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /mnt/config
+        - name: shared-volume
+          mountPath: /mnt/shared
+      containers:
+        - name: transport-controller
+          image: {{ .Values.controller.image }}:{{ .Values.controller.tag | default "latest" }}
+          imagePullPolicy: {{ .Values.controller.pullPolicy | default "Always" }}
+          args:
+          - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
+          - --wds-kubeconfig=/mnt/shared/wds-kubeconfig
+          - --wds-name={{ .Values.wds_cp_name }}
+          - -v=4
+          volumeMounts:
+          - name: shared-volume
+            mountPath: /mnt/shared
+            readOnly: true
+      {{- if .Values.local_image }}
+      hostAliases:
+      - ip: ${HOST_IP}
+        hostnames: [ "{{ .Values.wds_cp_name }}.localtest.me", "{{ .Values.transport_cp_name }}.localtest.me" ]
+      {{- end }}
+      volumes:
+      - name: shared-volume
+        emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: transport-controller-config
+          defaultMode: 0744

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -12,11 +12,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otp-controller-manager
+  namespace: {{.Values.wds_cp_name}}-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: otp-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: '{{.Values.wds_cp_name}}-otp-manager-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.kflex.kubestellar.org
+  resources:
+  - controlplanes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.kflex.kubestellar.org
+  resources:
+  - controlplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: otp-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: otp-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: otp-controller-manager
+  namespace: '{{.Values.wds_cp_name}}-system'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{.Values.wds_cp_name}}-otp-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{.Values.wds_cp_name}}-otp-manager-role'
+subjects:
+  - kind: ServiceAccount
+    name: otp-controller-manager
+    namespace: '{{.Values.wds_cp_name}}-system'
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: transport-controller-config
-  namespace: {{ .Values.wds_cp_name }}-system
+  namespace: {{.Values.wds_cp_name}}-system
 data:
   get-kubeconfig.sh: |
     #!/bin/bash
@@ -47,7 +148,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: transport-controller
-  namespace: {{ .Values.wds_cp_name }}-system
+  namespace: {{.Values.wds_cp_name}}-system
 spec:
   replicas: 1
   selector:
@@ -58,12 +159,12 @@ spec:
       labels:
         name: transport-controller
     spec:
-      serviceAccountName: kubestellar-controller-manager
+      serviceAccountName: otp-controller-manager
       initContainers:
       - name: setup-wds-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{ .Values.wds_cp_name }} true | base64 -d > /mnt/shared/wds-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{.Values.wds_cp_name}} true | base64 -d > /mnt/shared/wds-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config
@@ -72,7 +173,7 @@ spec:
       - name: setup-imbs-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{ .Values.transport_cp_name }} true | base64 -d > /mnt/shared/transport-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{.Values.transport_cp_name}} true | base64 -d > /mnt/shared/transport-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config
@@ -86,7 +187,7 @@ spec:
           args:
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
           - --wds-kubeconfig=/mnt/shared/wds-kubeconfig
-          - --wds-name={{ .Values.wds_cp_name }}
+          - --wds-name={{.Values.wds_cp_name}}
           - -v=4
           volumeMounts:
           - name: shared-volume

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -92,11 +92,6 @@ spec:
           - name: shared-volume
             mountPath: /mnt/shared
             readOnly: true
-      {{- if .Values.HOST_IP }}
-      hostAliases:
-      - ip: {{ .Values.HOST_IP }}
-        hostnames: [ "{{ .Values.wds_cp_name }}.localtest.me", "{{ .Values.transport_cp_name }}.localtest.me" ]
-      {{- end }}
       volumes:
       - name: shared-volume
         emptyDir: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Selet the operator image
+controller:
+  image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller
+  tag: 0.1.0.rc4
+  pullPolicy: IfNotPresent
+
+# Set the name of the WDS control plane
+wds_cp_name: wds1
+# Set the name of the transport control plane
+transport_cp_name: imbs1
+
+# Set local_image to true when running the chart with a locally built image,
+# e.g. during e2e testing
+local_image: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Selet the operator image
-controller:
-  image: ghcr.io/kubestellar/ocm-transport-plugin/transport-controller
-  tag: 0.1.0.rc4
-  pullPolicy: IfNotPresent
-
-# Set the name of the WDS control plane
-wds_cp_name: wds1
 # Set the name of the transport control plane
 transport_cp_name: imbs1
 
-# Set local_image to true when running the chart with a locally built image,
-# e.g. during e2e testing
-local_image: false
+# Set the name of the WDS control plane
+wds_cp_name: wds1
+
+# Set the HOST_IP to the host os ip address to use the chart with a locally built image (e.g. during e2e testing)
+# HOST_IP: <host os ip address>

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,3 @@ transport_cp_name: imbs1
 
 # Set the name of the WDS control plane
 wds_cp_name: wds1
-
-# Set the HOST_IP to the host os ip address to use the chart with a locally built image (e.g. during e2e testing)
-# HOST_IP: <host os ip address>


### PR DESCRIPTION
## Summary

Create am Helm chart for OTP

Tested to work in a kind cluster deployment of KubeStellar

To replace

```shell
bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBESTELLAR_VERSION}/scripts/deploy-transport-controller.sh) wds1 imbs1
```

using the local chart:

```shell
helm upgrade --install otp chart/ --set transport_cp_name=imbs1  --set wds_cp_name=wds1
```

In the future, when we have a packaged chart:

```shell
helm upgrade --install otp oci://ghcr.io/kubestellar/ocm-transport-plugin/transport-controller-chart --version 0.21.0-rc4 --set transport_cp_name=imbs1  --set wds_cp_name=wds1

```

## Related issue(s)

Fixes #
