### PR TITLE
🐛 Fix `v` issue

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -61,6 +61,6 @@ jobs:
     - name: Package and push chart
       run: |
         chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
-        sed -i 's@OTP_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
+        sed -i 's@OTP_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${chartVersion}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
         helm package ${{ env.CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion} --dependency-update
         helm push ./*.tgz oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary

I just tested the new chart... the new command for KS would be:

```shell
helm install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version 0.1.0 --set transport_cp_name=imbs1 --set wds_cp_name=wds1
```

However, there is an issue, the chart is referencing the controlelr image with a `v`:

```text
 Warning  Failed     19s (x3 over 56s)  kubelet            Failed to pull image "ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:v0.1.0": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:v0.1.0": failed to resolve reference "ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:v0.1.0": ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:v0.1.0: not found
```
I think we need to change the sed command in https://github.com/kubestellar/ocm-transport-plugin/blob/main/.github/workflows/goreleaser.yml from:

```shell
sed -i 's@OTP_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${{ github.ref_name }}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
```

to:

```shell
sed -i 's@OTP_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE }}:${chartVersion}@g' ${{ env.CHART_PATH }}/templates/controller.yaml
```

## Related issue(s)

Fixes #
