### PR TITLE
🐛 Fix cluster resource name conflicts

### DIFF
--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -22,7 +22,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: transport-controller-role
+  name: {{.Values.wds_cp_name}}-transport-controller-role
 rules:
 - apiGroups:
   - ""
@@ -52,11 +52,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: transport-controller-rolebinding
+  name: {{.Values.wds_cp_name}}-transport-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: transport-controller-role
+  name: {{.Values.wds_cp_name}}-transport-controller-role
 subjects:
   - kind: ServiceAccount
     name: transport-controller-sa


### PR DESCRIPTION
## Summary

This PR aims at fixing a naming conflict for cluster-level resources by prepending the wds name to the resources.
This issues presents itself when multiple WDS are used

## Related issue(s)

Fixes #
https://github.com/kubestellar/kubestellar/issues/2021