### PR TITLE
✨ Update the chart to prepare for PCH

### DIFF
--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -17,6 +17,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: transport-controller
+  namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -65,38 +66,37 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: transport-controller-config
+  namespace: {{.Release.Namespace}}
 data:
-  get-its-config.sh: |
+  get-config.sh: |
     #!/bin/env bash
-    its_name="${1%"-system"}" # ITS name or ITS namespace
-    if [ "$its_name" = "" ] ; then
+    cp_name="${1%"-system"}" # cp name or cp namespace
+    guess_its_name="$2"
+    if [ "$cp_name" == "" ] ; then
+      if [ "$guess_its_name" == "true" ] ; then
         for cp in `kubectl get controlplane -o name`; do
             cp=${cp##*/}
             if kubectl get controlplane $cp -o=jsonpath='{.metadata.labels}' | grep "imbs" &> /dev/null ; then
-                if [ "$its_name" = "" ] ; then
-                    its_name=$cp
+                if [ "$cp_name" = "" ] ; then
+                    cp_name=$cp
                 else
                     >&2 echo "ERROR: found more than one Control Plane of type imbs!"
                     exit 1
                 fi
             fi
         done
-        if [ "$its_name" = "" ] ; then
+        if [ "$cp_name" = "" ] ; then
             >&2 echo "ERROR: no Control Plane of type imbs found!"
             exit 2
         fi
+      else
+        >&2 echo "ERROR: no Control Plane name specified!"
+        exit 3
+      fi
     fi
-    key=$(kubectl get controlplane $its_name -o=jsonpath='{.status.secretRef.inClusterKey}')
-    secret_name=$(kubectl get controlplane $its_name -o=jsonpath='{.status.secretRef.name}')
-    secret_namespace=$(kubectl get controlplane $its_name -o=jsonpath='{.status.secretRef.namespace}')
-    # get the kubeconfig in base64
-    kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
-  get-wds-config.sh: |
-    #!/bin/env bash
-    wds_name="${1%"-system"}" # WDS name or WDS namespace
-    key=$(kubectl get controlplane $wds_name -o=jsonpath='{.status.secretRef.inClusterKey}')
-    secret_name=$(kubectl get controlplane $wds_name -o=jsonpath='{.status.secretRef.name}')
-    secret_namespace=$(kubectl get controlplane $wds_name -o=jsonpath='{.status.secretRef.namespace}')
+    key=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.inClusterKey}')
+    secret_name=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.namespace}')
     # get the kubeconfig in base64
     kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
 ---
@@ -104,6 +104,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: transport-controller
+  namespace: {{.Release.Namespace}}
 spec:
   replicas: 1
   selector:
@@ -119,7 +120,7 @@ spec:
       - name: setup-wds-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-wds-config.sh {{.Values.wds_cp_name}} | base64 -d > /mnt/shared/wds-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-config.sh {{.Values.wds_cp_name}} false | base64 -d > /mnt/shared/wds-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config
@@ -128,7 +129,7 @@ spec:
       - name: setup-its-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-its-config.sh {{.Values.transport_cp_name}} | base64 -d > /mnt/shared/transport-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-config.sh {{.Values.transport_cp_name}} true | base64 -d > /mnt/shared/transport-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -16,12 +16,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: transport-controller-sa
+  name: transport-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Values.wds_cp_name}}-transport-controller-role
+  name: {{.Values.wds_cp_name}}-transport-controller
 rules:
 - apiGroups:
   - ""
@@ -51,14 +51,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Values.wds_cp_name}}-transport-controller-rolebinding
+  name: {{.Values.wds_cp_name}}-transport-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{.Values.wds_cp_name}}-transport-controller-role
+  name: {{.Values.wds_cp_name}}-transport-controller
 subjects:
   - kind: ServiceAccount
-    name: transport-controller-sa
+    name: transport-controller
     namespace: {{.Release.Namespace}}
 ---
 apiVersion: v1
@@ -66,28 +66,37 @@ kind: ConfigMap
 metadata:
   name: transport-controller-config
 data:
-  get-kubeconfig.sh: |
-    #!/bin/bash
-    # this script receives a ControlPlane name and a parameter
-    # that determines whether to extract the ControlPlane's in-cluster kubeconfig
-    # or the external kubeconfig (if set to "true", the first will be retrieved).
-    # The function returns the requested kubeconfig's content in base64.
-    # it assumes the kubeconfig context is set to access the hosting cluster.
-
-    cpname="$1"
-    get_incluster_key="$2"
-
-    key=""
-    if [[ "$get_incluster_key" == "true" ]]; then
-      key=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.inClusterKey}');
-    else
-      key=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.key}');
+  get-its-config.sh: |
+    #!/bin/env bash
+    its_name="${1%"-system"}" # ITS name or ITS namespace
+    if [ "$its_name" = "" ] ; then
+        for cp in `kubectl get controlplane -o name`; do
+            cp=${cp##*/}
+            if kubectl get controlplane $cp -o=jsonpath='{.metadata.labels}' | grep "imbs" &> /dev/null ; then
+                if [ "$its_name" = "" ] ; then
+                    its_name=$cp
+                else
+                    >&2 echo "ERROR: found more than one Control Plane of type imbs!"
+                    exit 1
+                fi
+            fi
+        done
+        if [ "$its_name" = "" ] ; then
+            >&2 echo "ERROR: no Control Plane of type imbs found!"
+            exit 2
+        fi
     fi
-
-    # get secret details
-    secret_name=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.name}')
-    secret_namespace=$(kubectl get controlplane $cpname -o=jsonpath='{.status.secretRef.namespace}')
-
+    key=$(kubectl get controlplane $its_name -o=jsonpath='{.status.secretRef.inClusterKey}')
+    secret_name=$(kubectl get controlplane $its_name -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=$(kubectl get controlplane $its_name -o=jsonpath='{.status.secretRef.namespace}')
+    # get the kubeconfig in base64
+    kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
+  get-wds-config.sh: |
+    #!/bin/env bash
+    wds_name="${1%"-system"}" # WDS name or WDS namespace
+    key=$(kubectl get controlplane $wds_name -o=jsonpath='{.status.secretRef.inClusterKey}')
+    secret_name=$(kubectl get controlplane $wds_name -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=$(kubectl get controlplane $wds_name -o=jsonpath='{.status.secretRef.namespace}')
     # get the kubeconfig in base64
     kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
 ---
@@ -105,12 +114,12 @@ spec:
       labels:
         name: transport-controller
     spec:
-      serviceAccountName: transport-controller-sa
+      serviceAccountName: transport-controller
       initContainers:
       - name: setup-wds-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{.Values.wds_cp_name}} true | base64 -d > /mnt/shared/wds-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-wds-config.sh {{.Values.wds_cp_name}} | base64 -d > /mnt/shared/wds-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config
@@ -119,7 +128,7 @@ spec:
       - name: setup-its-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{.Values.transport_cp_name}} true | base64 -d > /mnt/shared/transport-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-its-config.sh {{.Values.transport_cp_name}} | base64 -d > /mnt/shared/transport-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -68,26 +68,28 @@ metadata:
   name: transport-controller-config
   namespace: {{.Release.Namespace}}
 data:
-  get-config.sh: |
+  get-kubeconfig.sh: |
     #!/bin/env bash
+    # Get the in-cluster kubeconfig for KubeFlex Control Planes
+    # get-kubeconfig.sh cp_name guess_its_name
     cp_name="${1%"-system"}" # cp name or cp namespace
-    guess_its_name="$2"
+    guess_its_name="$2" # true: try guessing the name of the ibms CP
     if [ "$cp_name" == "" ] ; then
       if [ "$guess_its_name" == "true" ] ; then
         for cp in `kubectl get controlplane -o name`; do
-            cp=${cp##*/}
-            if kubectl get controlplane $cp -o=jsonpath='{.metadata.labels}' | grep "imbs" &> /dev/null ; then
-                if [ "$cp_name" = "" ] ; then
-                    cp_name=$cp
-                else
-                    >&2 echo "ERROR: found more than one Control Plane of type imbs!"
-                    exit 1
-                fi
+          cp=${cp##*/} # separate just the CP name
+          if [ "$(kubectl get controlplane $cp -o jsonpath="{.metadata.labels['kflex\.kubestellar\.io/cptype']}")" == "imbs" ] ; then
+            if [ "$cp_name" == "" ] ; then
+              cp_name=$cp
+            else
+              >&2 echo "ERROR: found more than one Control Plane of type imbs!"
+              exit 1
             fi
+          fi
         done
-        if [ "$cp_name" = "" ] ; then
-            >&2 echo "ERROR: no Control Plane of type imbs found!"
-            exit 2
+        if [ "$cp_name" == "" ] ; then
+          >&2 echo "ERROR: no Control Plane of type imbs found!"
+          exit 2
         fi
       else
         >&2 echo "ERROR: no Control Plane name specified!"
@@ -120,7 +122,7 @@ spec:
       - name: setup-wds-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-config.sh {{.Values.wds_cp_name}} false | base64 -d > /mnt/shared/wds-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{.Values.wds_cp_name}} false | base64 -d > /mnt/shared/wds-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config
@@ -129,7 +131,7 @@ spec:
       - name: setup-its-kubeconfig
         image: quay.io/kubestellar/kubectl:1.27.8
         imagePullPolicy: Always
-        command: [ "bin/sh", "-c", "sh /mnt/config/get-config.sh {{.Values.transport_cp_name}} true | base64 -d > /mnt/shared/transport-kubeconfig"]
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh {{.Values.transport_cp_name}} true | base64 -d > /mnt/shared/transport-kubeconfig"]
         volumeMounts:
         - name: config-volume
           mountPath: /mnt/config

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -17,7 +17,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: transport-controller-sa
-  namespace: {{.Values.wds_cp_name}}-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -60,13 +59,12 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: transport-controller-sa
-    namespace: '{{.Values.wds_cp_name}}-system'
+    namespace: {{.Release.Namespace}}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: transport-controller-config
-  namespace: {{.Values.wds_cp_name}}-system
 data:
   get-kubeconfig.sh: |
     #!/bin/bash
@@ -97,7 +95,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: transport-controller
-  namespace: {{.Values.wds_cp_name}}-system
 spec:
   replicas: 1
   selector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Set the name of the transport control plane
-transport_cp_name: its1
+transport_cp_name: ""
 
 # Set the name of the WDS control plane
 wds_cp_name: wds1


### PR DESCRIPTION
## Summary

The purpose of this PR is to prepare the OTP chart for use by KubeStellar PCH.
In the future, we will use the new chart to simplify the user experience and incorporate the step 9 of the common setup into step 8.

Key changes:

1. the embedded CP namespace has been removed from the chart. This requires now to specify `--namespace <cp>-system` in the helm install command (this is automatically taken care by KubeFlex during the PCH installation)
2.  the script for obtaining the ITS kubeconfig has been updated to allow for empty `transport_cp_name`, which will default to the first and unique CP of type `imbs`
3. the script for obtaining the WDS kubeconfig has been updated to accept the namespace `wds-system` along the `wds` CP name (this to allow simplifications in the PCH)

Referring to step 9 of https://github.com/kubestellar/kubestellar/blob/main/docs/content/direct/examples.md, the new Helm installation command would be:

```shell
helm --kube-context kind-kubeflex upgrade --install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version ${OCM_TRANSPORT_PLUGIN} \
 --namespace wds1-system \
 --set transport_cp_name=imbs1 \
 --set wds_cp_name=wds1
```

However, in the future, we plan to modify the existing [KS PCH](https://github.com/kubestellar/kubestellar/blob/main/config/postcreate-hooks/kubestellar.yaml) to add a second container which will automatically install this OTP chart along with the KS chart along the lines proposed below: https://github.com/kubestellar/ocm-transport-plugin/pull/12#issuecomment-2049390167

One the new PCH will be available step 9 of the common setup instructions will not be necessary anymore and will not be exposed to the everyday user.

## Related issue(s)

Fixes #
