### PR TITLE
🐛 Improve initContainer to wait for ITS

### DIFF
--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -78,27 +78,28 @@ data:
     guess_its_name="$2" # true: try guessing the name of the ITS CP
 
     # check if the CP name is valid or needs to be guessed
-    if [ "$cp_name" == "" ] ; then
+    while [ "$cp_name" == "" ] ; do
       if [ "$guess_its_name" == "true" ] ; then
         cps=$(kubectl get controlplane -l 'kflex.kubestellar.io/cptype=its' 2> /dev/null | tail -n +2)
-        case $(echo "$cps" | wc -l) in
-        (0)
-          >&2 echo "Waiting for an ITS control plane to exist..."
-          sleep 10;;
-        (1)
-          cp_name="${cps%% *}";;
-        (*)
-          >&2 echo "ERROR: found more than one Control Plane of type its!"
-          exit 1;;
+        case $(echo -n "$cps" | grep -c '^') in
+          (0)
+            >&2 echo "Waiting for an ITS control plane to exist..."
+            sleep 10;;
+          (1)
+            cp_name="${cps%% *}"
+            break;;
+          (*)
+            >&2 echo "ERROR: found more than one Control Plane of type its!"
+            exit 1;;
         esac
       else
         >&2 echo "ERROR: no Control Plane name specified!"
         exit 3
       fi
-    fi
+    done
 
     # wait for the CP to exists and be ready
-    while [[ $(kubectl get controlplane $cp_name -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+    while [[ $(kubectl get controlplane "$cp_name" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
       >&2 echo "Waiting for \"$cp_name\" control plane to exist and be ready..."
       sleep 10
     done

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -72,34 +72,49 @@ data:
     #!/bin/env bash
     # Get the in-cluster kubeconfig for KubeFlex Control Planes
     # get-kubeconfig.sh cp_name guess_its_name
+
+    # input parameters
     cp_name="${1%"-system"}" # cp name or cp namespace
-    guess_its_name="$2" # true: try guessing the name of the ibms CP
+    guess_its_name="$2" # true: try guessing the name of the ITS CP
+
+    # check if the CP name is valid or needs to be guessed
     if [ "$cp_name" == "" ] ; then
       if [ "$guess_its_name" == "true" ] ; then
-        for cp in `kubectl get controlplane -o name`; do
-          cp=${cp##*/} # separate just the CP name
-          if [ "$(kubectl get controlplane $cp -o jsonpath="{.metadata.labels['kflex\.kubestellar\.io/cptype']}")" == "its" ] ; then
-            if [ "$cp_name" == "" ] ; then
-              cp_name="$cp"
-            else
-              >&2 echo "ERROR: found more than one Control Plane of type its!"
-              exit 1
+        while [ "$cp_name" == "" ] ; do
+          for cp in `kubectl get controlplane -o name`; do
+            cp=${cp##*/} # separate just the CP name
+            if [ "$(kubectl get controlplane $cp -o jsonpath="{.metadata.labels['kflex\.kubestellar\.io/cptype']}")" == "its" ] ; then
+              if [ "$cp_name" == "" ] ; then
+                cp_name="$cp"
+                break 2
+              else
+                >&2 echo "ERROR: found more than one Control Plane of type its!"
+                exit 1
+              fi
             fi
-          fi
+          done
+          >&2 echo "Waiting for an ITS control plane to exist..."
+          sleep 10
         done
-        if [ "$cp_name" == "" ] ; then
-          >&2 echo "ERROR: no Control Plane of type its found!"
-          exit 2
-        fi
       else
         >&2 echo "ERROR: no Control Plane name specified!"
         exit 3
       fi
     fi
+
+    # wait for the CP to exists and be ready
+    while [[ $(kubectl get controlplane $cp_name -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+      >&2 echo "Waiting for \"$cp_name\" control plane to exist and be ready..."
+      sleep 10
+    done
+
+    # determine the secret name and namespace
     key=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.inClusterKey}')
     secret_name=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.name}')
     secret_namespace=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.namespace}')
+
     # get the kubeconfig in base64
+    >&2 echo "Getting \"$key\" from \"$secret_name\" secret in \"$secret_namespace\" for control plane \"$cp_name\"..."
     kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
 ---
 apiVersion: apps/v1

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -80,22 +80,17 @@ data:
     # check if the CP name is valid or needs to be guessed
     if [ "$cp_name" == "" ] ; then
       if [ "$guess_its_name" == "true" ] ; then
-        while [ "$cp_name" == "" ] ; do
-          for cp in `kubectl get controlplane -o name`; do
-            cp=${cp##*/} # separate just the CP name
-            if [ "$(kubectl get controlplane $cp -o jsonpath="{.metadata.labels['kflex\.kubestellar\.io/cptype']}")" == "its" ] ; then
-              if [ "$cp_name" == "" ] ; then
-                cp_name="$cp"
-                break 2
-              else
-                >&2 echo "ERROR: found more than one Control Plane of type its!"
-                exit 1
-              fi
-            fi
-          done
+        cps=$(kubectl get controlplane -l 'kflex.kubestellar.io/cptype=its' 2> /dev/null | tail -n +2)
+        case $(echo "$cps" | wc -l) in
+        (0)
           >&2 echo "Waiting for an ITS control plane to exist..."
-          sleep 10
-        done
+          sleep 10;;
+        (1)
+          cp_name="${cps%% *}";;
+        (*)
+          >&2 echo "ERROR: found more than one Control Plane of type its!"
+          exit 1;;
+        esac
       else
         >&2 echo "ERROR: no Control Plane name specified!"
         exit 3
@@ -160,7 +155,7 @@ spec:
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
           - --wds-kubeconfig=/mnt/shared/wds-kubeconfig
           - --wds-name={{.Values.wds_cp_name}}
-          - -v={{.Values.verbosity}}
+          - -v={{.Values.verbosity | default 4}}
           volumeMounts:
           - name: shared-volume
             mountPath: /mnt/shared


### PR DESCRIPTION
## Summary

Improve the `get-kubeconfig.sh` script to wait for the existence of the ITS control plane instead of exiting with an error.

This addresses the situation where the OTP controller is spun up before the ITS exists or is ready.

## Related issue(s)

Fixes #
